### PR TITLE
"Bearer " was getting removed from tokens which were then passed thro…

### DIFF
--- a/library/src/main/java/io/mifos/anubis/security/SystemAuthenticator.java
+++ b/library/src/main/java/io/mifos/anubis/security/SystemAuthenticator.java
@@ -78,7 +78,7 @@ public class SystemAuthenticator {
       jwtParser.parse(token);
       logger.info("System token for user {}, with key timestamp {} authenticated successfully.", user, keyTimestamp);
 
-      return new AnubisAuthentication(token, user, permissions);
+      return new AnubisAuthentication(TokenConstants.PREFIX + token, user, permissions);
     }
     catch (final JwtException e) {
       logger.debug("token = {}", token);

--- a/library/src/main/java/io/mifos/anubis/security/TenantAuthenticator.java
+++ b/library/src/main/java/io/mifos/anubis/security/TenantAuthenticator.java
@@ -87,7 +87,7 @@ public class TenantAuthenticator {
 
       logger.info("Tenant token for user {}, with key timestamp {} authenticated successfully.", user, keyTimestamp);
 
-      return new AnubisAuthentication(token,
+      return new AnubisAuthentication(TokenConstants.PREFIX + token,
           jwt.getBody().getSubject(), permissions
       );
     }


### PR DESCRIPTION
…ugh without the prefix to embedded calls.